### PR TITLE
more legible lambdas

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,18 +23,12 @@ julia> h(3)
 2.0
 ```
 
-_____
-LegibleLambdas currently aren't as ideally legible as I'd like. For instance,
+If you use it in julia **v1.1+**, it will be more legible
+
 ```julia
 julia> D(f, ϵ=1e-10) = @λ(x -> (f(x+ϵ)-f(x))/ϵ)
 D (generic function with 2 methods)
 
 julia> D(sin)
-(x->(f(x + ϵ) - f(x)) / ϵ)
-```
-whereas in a perfect world the output of the last line would be
-```julia
 (x->(sin(x + 1e-10) - sin(x)) / 1e-10)
 ```
-so if you know how to make the above work, I'd love to hear from you. The real problem is that to do that, you'd need to expand the macro at the function runtime instead of compile time. 
-<!-- LegibleLambdas:1 ends here -->

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ julia> h(3)
 2.0
 ```
 
-If you use it in julia **v1.1+**, it will be more legible
+If you use julia **v1.1+**, anonymous returned by other functions will also benefit from increased legibility
 
 ```julia
 julia> D(f, ϵ=1e-10) = @λ(x -> (f(x+ϵ)-f(x))/ϵ)

--- a/src/LegibleLambdas.jl
+++ b/src/LegibleLambdas.jl
@@ -22,7 +22,7 @@ julia> @λ(x -> g(x)/3)
     macro λ(ex)
         if ex.head == :(->)
             ex_cut = ex |> (ex -> postwalk(cutlnn, ex)) |> (ex -> postwalk(cutblock, ex))
-            name = (repr(ex_cut)[2:end])
+            name = replace((repr(ex_cut)[2:end]), "->" => " -> ")
             :(LegibleLambda($name, $(esc(ex))))
         else
             throw("Must be called on a Lambda expression")
@@ -73,7 +73,7 @@ else
         end
 
         ex_cut = ex |> (ex -> postwalk(cutlnn, ex)) |> (ex -> postwalk(cutblock, ex))
-        return (repr(ex_cut)[2:end])
+        return replace((repr(ex_cut)[2:end]), "->" => " -> ")
     end
 
     function Base.show(io::IO, f::LegibleLambda)

--- a/src/LegibleLambdas.jl
+++ b/src/LegibleLambdas.jl
@@ -1,29 +1,97 @@
-# [[file:~/Documents/Julia/scrap.org::*LegibleLambdas][LegibleLambdas:2]]
 module LegibleLambdas
 
 using MacroTools: postwalk
+export @λ, @lambda, LegibleLambda
 
-export @λ, LegibleLambda
+"""
+    @λ <lambda definition>
 
-macro λ(ex)
-    if ex.head == :(->)
-        ex_cut = ex |> (ex -> postwalk(cutlnn, ex)) |> (ex -> postwalk(cutblock, ex))
-        name = (repr(ex_cut)[2:end])
-        :(LegibleLambda($name, $(esc(ex))))
-    else
-        throw("Must be called on a Lambda expression")
+Create legible lambdas.
+
+# Example
+
+```julia
+julia> @λ(x -> g(x)/3)
+(x -> g(x)/3)
+```
+"""
+:(@λ)
+
+# NOTE: Base.@locals is in v1.1
+@static if VERSION < v"1.1.0"
+    macro λ(ex)
+        if ex.head == :(->)
+            ex_cut = ex |> (ex -> postwalk(cutlnn, ex)) |> (ex -> postwalk(cutblock, ex))
+            name = (repr(ex_cut)[2:end])
+            :(LegibleLambda($name, $(esc(ex))))
+        else
+            throw("Must be called on a Lambda expression")
+        end
     end
+
+    struct LegibleLambda{F <: Function} <: Function
+        name::String
+        λ::F
+    end
+
+    (f::LegibleLambda)(args...) = (f.λ)(args...)
+
+    function Base.show(io::IO, f::LegibleLambda)
+        print(io, f.name)
+    end
+
+    function Base.show(io::IO, ::MIME"text/plain", f::LegibleLambda)
+        print(io, f.name)
+    end
+
+else
+
+    macro λ(ex)
+        if ex.head == :(->)
+            ex_cut = ex |> (ex -> postwalk(cutlnn, ex)) |> (ex -> postwalk(cutblock, ex))
+            name = (repr(ex_cut)[2:end])
+            return quote
+                LegibleLambda($(esc(ex)), $(QuoteNode(ex)), Base.@locals)
+            end
+        else
+            throw("Must be called on a Lambda expression")
+        end
+    end
+
+    struct LegibleLambda{F, T}
+        λ::F
+        ex::Expr
+        vars::Dict{Symbol, T}
+    end
+
+    (f::LegibleLambda)(args...; kwargs...) = (f.λ)(args...; kwargs...)
+
+    function to_string(f::LegibleLambda)
+        ex = f.ex
+        for (s, v) in f.vars
+            ex = postwalk(x->x === s ? v : x, ex)
+        end
+
+        ex_cut = ex |> (ex -> postwalk(cutlnn, ex)) |> (ex -> postwalk(cutblock, ex))
+        return (repr(ex_cut)[2:end])
+    end
+
+    function Base.show(io::IO, f::LegibleLambda)
+        print(io, to_string(f))
+    end
+
+    function Base.show(io::IO, ::MIME"text/plain", f::LegibleLambda)
+        print(io, to_string(f))
+    end
+
 end
 
-struct LegibleLambda <: Function
-    name::String
-    λ::Function
+macro lambda(ex)
+    return :(@λ($ex))
 end
-
-(f::LegibleLambda)(args...) = (f.λ)(args...)
 
 cutlnn(x) = x
-function cutlnn(ex::Expr) 
+function cutlnn(ex::Expr)
     Expr(ex.head, ex.args[[!(arg isa LineNumberNode) for arg in ex.args]]...)
 end
 
@@ -45,17 +113,4 @@ function tupleargs(ex::Expr)
     end
 end
 
-
-function Base.show(io::IO, f::LegibleLambda)
-    print(io, f.name)
 end
-
-function Base.show(io::IO, ::MIME"text/plain", f::LegibleLambda)
-    print(io, f.name)
-end
-
-
-
-
-end
-# LegibleLambdas:2 ends here

--- a/src/LegibleLambdas.jl
+++ b/src/LegibleLambdas.jl
@@ -58,7 +58,7 @@ else
         end
     end
 
-    struct LegibleLambda{F, T}
+    struct LegibleLambda{F <: Function, T} <: Function
         λ::F
         ex::Expr
         vars::Dict{Symbol, T}

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -17,6 +17,12 @@ using Test, LegibleLambdas
     @test h("hi", "abh", "ing")
 
     D(f, ϵ=1e-10) = @λ(x -> (f(x+ϵ)-f(x))/ϵ)
-    @test repr(D(sin)) == "(x->((sin)(x + 1.0e-10) - (sin)(x)) / 1.0e-10)"
+    
+    if VERSION < v"1.1.0"
+        @test repr(D(sin)) == "(x->(f(x + ϵ) - f(x)) / ϵ)" 
+    else
+        @test repr(D(sin)) == "(x->((sin)(x + 1.0e-10) - (sin)(x)) / 1.0e-10)"
+    end
+    
     @test D(sin)(π) == -1.000000082740371
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,6 +1,3 @@
-# Tests
-
-# [[file:~/Documents/Julia/scrap.org::*Tests][Tests:1]]
 using Test, LegibleLambdas
 
 @testset "Legible Lambdas" begin
@@ -20,7 +17,6 @@ using Test, LegibleLambdas
     @test h("hi", "abh", "ing")
 
     D(f, ϵ=1e-10) = @λ(x -> (f(x+ϵ)-f(x))/ϵ)
-    @test repr(D(sin)) == "(x->(f(x + ϵ) - f(x)) / ϵ)"
+    @test repr(D(sin)) == "(x->((sin)(x + 1.0e-10) - (sin)(x)) / 1.0e-10)"
     @test D(sin)(π) == -1.000000082740371
 end
-# Tests:1 ends here

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -3,25 +3,25 @@ using Test, LegibleLambdas
 @testset "Legible Lambdas" begin
     f = @λ(x -> x + 1)
     @test f isa Function
-    @test repr(f) == "(x->x + 1)"
+    @test repr(f) == "(x -> x + 1)"
     @test f(2) == 3
 
     g = @λ((x,y) -> x^2 + y^2)
     @test g isa Function
-    @test repr(g) == "((x, y)->x ^ 2 + y ^ 2)"
+    @test repr(g) == "((x, y) -> x ^ 2 + y ^ 2)"
     @test g(-15.0, 10.0) == 325.0
 
     h = @λ((x,y, z) -> occursin(x, y*z))
     @test h isa Function
-    @test repr(h) == "((x, y, z)->occursin(x, y * z))"
+    @test repr(h) == "((x, y, z) -> occursin(x, y * z))"
     @test h("hi", "abh", "ing")
 
     D(f, ϵ=1e-10) = @λ(x -> (f(x+ϵ)-f(x))/ϵ)
     
     if VERSION < v"1.1.0"
-        @test repr(D(sin)) == "(x->(f(x + ϵ) - f(x)) / ϵ)" 
+        @test repr(D(sin)) == "(x -> (f(x + ϵ) - f(x)) / ϵ)" 
     else
-        @test repr(D(sin)) == "(x->((sin)(x + 1.0e-10) - (sin)(x)) / 1.0e-10)"
+        @test repr(D(sin)) == "(x -> ((sin)(x + 1.0e-10) - (sin)(x)) / 1.0e-10)"
     end
     
     @test D(sin)(π) == -1.000000082740371


### PR DESCRIPTION
I guess this doable in v1.1 era. And maybe register the package? I'm using it in 
a base package of https://github.com/QuantumBFS/Yao.jl here: 

https://github.com/QuantumBFS/YaoBase.jl/blob/master/src/utils/legible_lambdas.jl

PS. I'm not sure if I should remove the parenthesis around functions while printing 